### PR TITLE
(maint) Fix method name typo

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -101,7 +101,7 @@ facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
 puppet_older_than_3_5_0 = !puppet_version.nil? && 
-  Gem::Version.correct(puppet_version) &&
+  Gem::Version.correct?(puppet_version) &&
   Gem::Requirement.new('< 3.5.0').satisfied_by?(Gem::Version.new(puppet_version.dup))
 
 gem 'puppet', *location_for(puppet_version)


### PR DESCRIPTION
Gem::Version does not have 'correct' but does have 'correct?'