### PR TITLE
(MAINT) Bump beaker pin to minimum version that supports ruby 2.1.9.

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -491,7 +491,7 @@ Gemfile:
           - mingw
           - x64_mingw
       - gem: beaker
-        version: '>= 3'
+        version: '~> 3.13'
         from_env: BEAKER_VERSION
       - gem: beaker-pe
       - gem: beaker-rspec


### PR DESCRIPTION
For some reason this was resolving to 3.3.0 on Windows which doesn't support ruby 2.1.9.