### PR TITLE
(maint) Fix rubocop offenses in template

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -458,30 +458,30 @@ spec/spec_opts:
 Gemfile:
   required:
     ':development':
+      - gem: fast_gettext
+        version: '1.1.0'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
+      - gem: fast_gettext
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
+      # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to
+      # json_pure <= 2.0.1 if using ruby 1.x
+      - gem: json_pure
+        version: '<= 2.0.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
       - gem: 'puppet-module-posix-default-r#{minor_version}'
+        platforms: ruby
+      - gem: 'puppet-module-posix-dev-r#{minor_version}'
         platforms: ruby
       - gem: 'puppet-module-win-default-r#{minor_version}'
         platform:
           - mswin
           - mingw
           - x64_mingw
-      - gem: 'puppet-module-posix-dev-r#{minor_version}'
-        platforms: ruby
       - gem: 'puppet-module-win-dev-r#{minor_version}'
         platforms:
           - mswin
           - mingw
           - x64_mingw
-      # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to
-      # json_pure <= 2.0.1 if using ruby 1.x
-      - gem: json_pure
-        version: '<= 2.0.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
-      - gem: fast_gettext
-        version: '1.1.0'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
-      - gem: fast_gettext
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
     ':system_tests':
       - gem: 'puppet-module-posix-system-r#{minor_version}'
         platforms: ruby
@@ -493,11 +493,11 @@ Gemfile:
       - gem: beaker
         version: '~> 3.13'
         from_env: BEAKER_VERSION
-      - gem: beaker-pe
-      - gem: beaker-rspec
-        from_env: BEAKER_RSPEC_VERSION
-      - gem: beaker-hostgenerator
-        from_env: BEAKER_HOSTGENERATOR_VERSION
       - gem: beaker-abs
         from_env: BEAKER_ABS_VERSION
         version: '~> 0.1'
+      - gem: beaker-pe
+      - gem: beaker-hostgenerator
+        from_env: BEAKER_HOSTGENERATOR_VERSION
+      - gem: beaker-rspec
+        from_env: BEAKER_RSPEC_VERSION

--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -6,12 +6,14 @@ defaults = {
     'TargetRubyVersion' => '2.1',
     'Include' => [
       './**/*.rb',
+      '**/Gemfile',
     ],
     'Exclude'=> [
       "vendor/**/*",
       ".vendor/**/*",
       "pkg/**/*",
       "spec/fixtures/**/*",
+      'bin/*',
     ],
   },
 }

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -21,11 +21,11 @@ def gem_spec(gem, max_len)
   end
 
   options = []
-  options << ":require => false" if gem['from_env'].nil?
-  options << ":git => '#{gem['git']}'" unless gem['git'].nil?
-  options << ":branch => '#{gem['branch']}'" unless gem['branch'].nil?
-  options << ":ref => '#{gem['ref']}'" unless gem['branch'].nil?
-  options << ":platforms => #{gem['platforms'].inspect}" unless gem['platforms'].nil?
+  options << "require: false" if gem['from_env'].nil?
+  options << "git: '#{gem['git']}'" unless gem['git'].nil?
+  options << "branch: '#{gem['branch']}'" unless gem['branch'].nil?
+  options << "ref: '#{gem['ref']}'" unless gem['branch'].nil?
+  options << "platforms: #{gem['platforms'].inspect}" unless gem['platforms'].nil?
   
   unless options.empty?
     output += ', '
@@ -39,22 +39,22 @@ def gem_spec(gem, max_len)
   output
 end
 -%>
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place_or_version, fake_version = nil)
-  if place_or_version =~ /\A(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place_or_version =~ /\Afile:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  if place_or_version =~ %r{\A(git[:@][^#]*)#(.*)}
+    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
+  elsif place_or_version =~ %r{\Afile:\/\/(.*)}
+    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
   else
-    [place_or_version, { :require => false }]
+    [place_or_version, { require: false }]
   end
 end
 
 def gem_type(place_or_version)
-  if place_or_version =~ /\Agit[:@]/
+  if place_or_version =~ %r{\Agit[:@]}
     :git
-  elsif place_or_version =~ /\Afile:/
+  elsif !place_or_version.nil? && place_or_version.start_with?('file:')
     :file
   else
     :gem
@@ -64,6 +64,7 @@ end
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
+# rubocop:disable Bundler/DuplicatedGem, Bundler/OrderedGems, Style/StringLiterals, Layout/ExtraSpacing
 <% 
   groups = {}
   (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key|
@@ -94,75 +95,85 @@ group <%= group %> do
 <%   end -%>
 end
 <% end -%>
+# rubocop:enable Bundler/DuplicatedGem, Bundler/OrderedGems, Style/StringLiterals, Layout/ExtraSpacing
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
-puppet_older_than_3_5_0 = !puppet_version.nil? && 
-  Gem::Version.correct?(puppet_version) &&
-  Gem::Requirement.new('< 3.5.0').satisfied_by?(Gem::Version.new(puppet_version.dup))
+def puppet_older_than?(version)
+  puppet_version = ENV['PUPPET_GEM_VERSION']
+  !puppet_version.nil? &&
+    Gem::Version.correct?(puppet_version) &&
+    Gem::Requirement.new("< #{version}").satisfied_by?(Gem::Version.new(puppet_version.dup))
+end
 
-gem 'puppet', *location_for(puppet_version)
+gems = {}
+
+gems['puppet'] = location_for(puppet_version)
 
 # If facter or hiera versions have been specified via the environment
 # variables, use those versions. If not, and if the puppet version is < 3.5.0,
 # use known good versions of both for puppet < 3.5.0.
 if facter_version
-  gem 'facter', *location_for(facter_version)
-elsif puppet_type == :gem && puppet_older_than_3_5_0
-  gem 'facter', '>= 1.6.11', '<= 1.7.5', :require => false
+  gems['facter'] = location_for(facter_version)
+elsif puppet_type == :gem && puppet_older_than?('3.5.0')
+  gems['facter'] = ['>= 1.6.11', '<= 1.7.5', require: false]
 end
 
 if hiera_version
-  gem 'hiera', *location_for(ENV['HIERA_GEM_VERSION'])
-elsif puppet_type == :gem && puppet_older_than_3_5_0
-  gem 'hiera', '>= 1.0.0', '<= 1.3.0', :require => false
+  gems['hiera'] = location_for(ENV['HIERA_GEM_VERSION'])
+elsif puppet_type == :gem && puppet_older_than?('3.5.0')
+  gem['hiera'] = ['>= 1.0.0', '<= 1.3.0', require: false]
 end
 
-if Gem.win_platform? && (puppet_type != :gem || puppet_older_than_3_5_0)
+if Gem.win_platform? && (puppet_type != :gem || puppet_older_than?('3.5.0'))
   # For Puppet gems < 3.5.0 (tested as far back as 3.0.0) on Windows
   if puppet_type == :gem
-    gem 'ffi',            '1.9.0',                :require => false
-    gem 'win32-eventlog', '0.5.3',    '<= 0.6.5', :require => false
-    gem 'win32-process',  '0.6.5',    '<= 0.7.5', :require => false
-    gem 'win32-security', '~> 0.1.2', '<= 0.2.5', :require => false
-    gem 'win32-service',  '0.7.2',    '<= 0.8.8', :require => false
-    gem 'minitar',        '0.5.4',                :require => false
+    gems['ffi'] =            ['1.9.0',                require: false]
+    gems['minitar'] =        ['0.5.4',                require: false]
+    gems['win32-eventlog'] = ['0.5.3',    '<= 0.6.5', require: false]
+    gems['win32-process'] =  ['0.6.5',    '<= 0.7.5', require: false]
+    gems['win32-security'] = ['~> 0.1.2', '<= 0.2.5', require: false]
+    gems['win32-service'] =  ['0.7.2',    '<= 0.8.8', require: false]
   else
-    gem 'ffi',            '~> 1.9.0',             :require => false
-    gem 'win32-eventlog', '~> 0.5',   '<= 0.6.5', :require => false
-    gem 'win32-process',  '~> 0.6',   '<= 0.7.5', :require => false
-    gem 'win32-security', '~> 0.1',   '<= 0.2.5', :require => false
-    gem 'win32-service',  '~> 0.7',   '<= 0.8.8', :require => false
-    gem 'minitar',        '~> 0.5.4',             :require => false
+    gems['ffi'] =            ['~> 1.9.0',             require: false]
+    gems['minitar'] =        ['~> 0.5.4',             require: false]
+    gems['win32-eventlog'] = ['~> 0.5',   '<= 0.6.5', require: false]
+    gems['win32-process'] =  ['~> 0.6',   '<= 0.7.5', require: false]
+    gems['win32-security'] = ['~> 0.1',   '<= 0.2.5', require: false]
+    gems['win32-service'] =  ['~> 0.7',   '<= 0.8.8', require: false]
   end
 
-  gem 'win32-dir', '~> 0.3', '<= 0.4.9', :require => false
+  gems['win32-dir'] = ['~> 0.3', '<= 0.4.9', require: false]
 
-  if RUBY_VERSION =~ /\A1\./
-    gem 'win32console', '1.3.2', :require => false
+  if RUBY_VERSION.start_with?('1.')
+    gems['win32console'] = ['1.3.2', require: false]
     # sys-admin was removed in Puppet 3.7.0 and doesn't compile under Ruby 2.x
-    gem 'sys-admin',    '1.5.6', :require => false
+    gems['sys-admin'] =    ['1.5.6', require: false]
   end
 
   # Puppet < 3.7.0 requires these.
   # Puppet >= 3.5.0 gem includes these as requirements.
   # The following versions are tested to work with 3.0.0 <= puppet < 3.7.0.
-  gem 'win32-api',           '1.4.8', :require => false
-  gem 'win32-taskscheduler', '0.2.2', :require => false
-  gem 'windows-api',         '0.4.3', :require => false
-  gem 'windows-pr',          '1.2.3', :require => false
+  gems['win32-api'] =           ['1.4.8', require: false]
+  gems['win32-taskscheduler'] = ['0.2.2', require: false]
+  gems['windows-api'] =         ['0.4.3', require: false]
+  gems['windows-pr'] =          ['1.2.3', require: false]
 elsif Gem.win_platform?
   # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
   # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gem 'win32-dir',      '<= 0.4.9', :require => false
-  gem 'win32-eventlog', '<= 0.6.5', :require => false
-  gem 'win32-process',  '<= 0.7.5', :require => false
-  gem 'win32-security', '<= 0.2.5', :require => false
-  gem 'win32-service',  '<= 0.8.8', :require => false
-  end
+  gems['win32-dir'] =      ['<= 0.4.9', require: false]
+  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
+  gems['win32-process'] =  ['<= 0.7.5', require: false]
+  gems['win32-security'] = ['<= 0.2.5', require: false]
+  gems['win32-service'] =  ['<= 0.8.8', require: false]
+end
+
+gems.each do |gem_name, gem_params|
+  gem gem_name, *gem_params
+end
 
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
@@ -172,7 +183,7 @@ extra_gemfiles = [
 
 extra_gemfiles.each do |gemfile|
   if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
+    eval(File.read(gemfile), binding) # rubocop:disable Security/Eval
   end
 end
 # vim: syntax=ruby

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -9,7 +9,7 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::Console,
-    Coveralls::SimpleCov::Formatter
+    Coveralls::SimpleCov::Formatter,
   ]
   SimpleCov.start do
     track_files 'lib/**/*.rb'
@@ -20,19 +20,19 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
 end
 
 default_facts = {
-  :puppetversion => Puppet.version,
-  :facterversion => Facter.version,
+  puppetversion: Puppet.version,
+  facterversion: Facter.version,
 }
 
 default_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml'))
 default_module_facts_path = File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
 
 if File.exist?(default_facts_path) && File.readable?(default_facts_path)
-  default_facts.merge!(YAML.load(File.read(default_facts_path)))
+  default_facts.merge!(YAML.safe_load(File.read(default_facts_path)))
 end
 
 if File.exist?(default_module_facts_path) && File.readable?(default_module_facts_path)
-  default_facts.merge!(YAML.load(File.read(default_module_facts_path)))
+  default_facts.merge!(YAML.safe_load(File.read(default_module_facts_path)))
 end
 
 RSpec.configure do |c|
@@ -44,7 +44,6 @@ RSpec.configure do |c|
   c.hiera_config = <%= @configs['hiera_config'] %>
   <%- end -%>
 end
-
 <%- [@configs['spec_overrides']].flatten.compact.each do |line| -%>
 <%= line %>
 <%- end -%>


### PR DESCRIPTION
Cleans up all the rubocop offenses in the generated template

```                                                                                      
asmodean :0: puppet/pdk git:(junit)!» bin/pdk new module foo --skip-interview --template-url file:///home/tsharpe/code/puppet/pdk-module-template
pdk (INFO): Creating new module: foo
asmodean :0: puppet/pdk git:(junit)!» cd foo                                                                                                     
asmodean :0: pdk/foo git:(junit)!» ../bin/pdk validate ruby                                                                                   
[✔] Checking for missing Gemfile dependencies
asmodean :0: pdk/foo git:(junit)!» 
```