### PR TITLE
(SDK-322) Spec tests should specify facter 2.4

### DIFF
--- a/object_templates/class_spec.erb
+++ b/object_templates/class_spec.erb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe '<%= name %>' do
-  on_supported_os.each do |os, os_facts|
+  on_supported_os(facterversion: '2.4').each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 


### PR DESCRIPTION
Facter 2.5 is available but rspec-puppet-facts has no facts for this version yet.
So the spec test template should specify facter 2.4 for on_supported_os