### PR TITLE
(PDK-357) Nicer rubocop-rspec config for module developers

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -389,7 +389,6 @@ spec/spec_opts:
         RSpec/DescribeMethod:
         RSpec/DescribeSymbol:
         RSpec/EmptyExampleGroup:
-        RSpec/ExampleLength:
         RSpec/ExpectActual:
         RSpec/ExpectOutput:
         RSpec/FilePath:
@@ -400,9 +399,7 @@ spec/spec_opts:
         RSpec/MessageChain:
         RSpec/MessageSpies:
         RSpec/MultipleDescribes:
-        RSpec/MultipleExpectations:
         RSpec/NamedSubject:
-        RSpec/NestedGroups:
         RSpec/OverwritingSetup:
         RSpec/RepeatedDescription:
         RSpec/RepeatedExample:


### PR DESCRIPTION
Moves the `RSpec/{ExampleLength,MultipleExpectation,NestedGroups}` cops out of the default `strict` profile so that they'll only be enabled if the user opts into the `hardcore` profile.

None of the issues that these cops catch are *serious* problems really, so having them enabled by default is just going to cause user pain and alert fatigue.