### PR TITLE
(PDK-443) Disables EndOfLine style cop to accommodate Windows.

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -99,7 +99,7 @@ spec/spec_opts:
       EnforcedStyle: brackets
 
     Style/EndOfLine:
-      EnforcedStyle: lf
+      Enabled: false
   cleanup_cops: &cleanup_cops
     Bundler/OrderedGems:
     Layout/AccessModifierIndentation:


### PR DESCRIPTION
This is another PR in reference to an issue validating ruby files on Windows with PDk. 
https://github.com/puppetlabs/pdk/issues/267

Further, I did some research and discovered that the official stance of rubocop (and the Ruby Style guide) is to expect Unix-style line endings and "be careful" on Windows.
https://github.com/bbatsov/rubocop/issues/206