### PR TITLE
[PDK-466] Add .fixtures.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/moduleroot/.fixtures.yml.erb
+++ b/moduleroot/.fixtures.yml.erb
@@ -1,0 +1,6 @@
+---
+fixtures:
+  repositories:
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
+  symlinks:
+    simp: "#{source_dir}"


### PR DESCRIPTION
This commit adds a basic fixtures.yml to ensure that users can take advantage of the default module dependency of `puppetlabs/stdlib`.