### PR TITLE
(PDK-447) Update Appveyor to run all CI jobs & bump to Ruby 2.4.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -27,13 +27,21 @@
     - env: CHECK=metadata_lint
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests"
+  environment:
+    PUPPET_GEM_VERSION: "~> 4.0"
   matrix:
-    - PUPPET_GEM_VERSION: "~> 4.0"
-      RUBY_VERSION: 21-x64
-    - PUPPET_GEM_VERSION: "~> 4.0"
-      RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 23-x64
+      CHECK: "syntax lint"
+    - RUBY_VERSION: 23-x64
+      CHECK: metadata_lint
+    - RUBY_VERSION: 23-x64
+      CHECK: rubocop
+    - RUBY_VERSION: 23-x64
+      CHECK: spec
+    - RUBY_VERSION: 21-x64
+      CHECK: spec
   test_script:
-    - bundle exec rake spec
+    - bundle exec rake %CHECK%
 Rakefile:
   default_disabled_lint_checks:
     - 'relative'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -30,13 +30,13 @@ appveyor.yml:
   environment:
     PUPPET_GEM_VERSION: "~> 4.0"
   matrix:
-    - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24-x64
       CHECK: "syntax lint"
-    - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24-x64
       CHECK: metadata_lint
-    - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24-x64
       CHECK: rubocop
-    - RUBY_VERSION: 23-x64
+    - RUBY_VERSION: 24-x64
       CHECK: spec
     - RUBY_VERSION: 21-x64
       CHECK: spec

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -9,11 +9,16 @@ init:
   - 'mkdir C:\ProgramData\PuppetLabs\hiera && exit 0'
   - 'mkdir C:\ProgramData\PuppetLabs\puppet\var && exit 0'
 environment:
+<%- (@configs['environment'] || []).each do |key, value| -%>
+  <%= key %>: <%= value %>
+<%- end -%>
   matrix:
-<% (@configs['matrix'] + (@configs['matrix_extras'] || [])).each do |matrix| -%>
-    - PUPPET_GEM_VERSION: <%= matrix['PUPPET_GEM_VERSION'] %>
-      RUBY_VERSION: <%= matrix['RUBY_VERSION'] %>
-<% end -%>
+<%- (@configs['matrix'] + (@configs['matrix_extras'] || [])).each do |matrix| -%>
+    -
+  <%- matrix.each do |key, value| -%>
+      <%= key %>: <%= value %>
+  <%- end -%>
+<%- end -%>
 matrix:
   fast_finish: true
 install:

--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -23,6 +23,17 @@ matrix:
   fast_finish: true
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  # Due to a bug in the version of OpenSSL shipped with Ruby 2.4.1 on Windows
+  # (https://bugs.ruby-lang.org/issues/11033). Errors are ignored because the
+  # mingw gem calls out to pacman to install OpenSSL which is already
+  # installed, causing gem to raise a warning that powershell determines to be
+  # a fatal error.
+  - ps: |
+      $ErrorActionPreference = "SilentlyContinue"
+      if($env:RUBY_VERSION -eq "24-x64") {
+        gem install openssl "~> 2.0.4" --no-rdoc --no-ri -- --with-openssl-dir=C:\msys64\mingw64
+      }
+      $host.SetShouldExit(0)
   - <%= @configs['appveyor_bundle_install'] %>
   - type Gemfile.lock
 build: off


### PR DESCRIPTION
This change makes Appveyor run the same jobs as Travis. Unfortunately, Appveyor's preinstalled Rubies aren't as specific as Travis, so the best we can do is specify the minor version.

Only real interesting change here is the upgrade of the openssl gem when running Ruby 2.4.x on Windows, due to https://bugs.ruby-lang.org/issues/11033.

Example build with this configuration: https://ci.appveyor.com/project/rodjek/pdk-testmodule/build/1.1.x.12