### PR TITLE
(MAINT) properly disable Layout/EndOfLine

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -101,8 +101,6 @@ spec/spec_opts:
       Description: Using percent style obscures symbolic intent of array's contents.
       EnforcedStyle: brackets
 
-    Style/EndOfLine:
-      Enabled: false
   cleanup_cops: &cleanup_cops
     Bundler/OrderedGems:
     Layout/AccessModifierIndentation:
@@ -330,7 +328,6 @@ spec/spec_opts:
         <<: *cleanup_cops
         Bundler/DuplicatedGem:
         Layout/EmptyLinesAroundBeginBody:
-        Layout/EndOfLine:
         Lint/AmbiguousBlockAssociation:
         Lint/AmbiguousOperator:
         Lint/AmbiguousRegexpLiteral:

--- a/rubocop/defaults-0.49.1.yml
+++ b/rubocop/defaults-0.49.1.yml
@@ -22,7 +22,6 @@
 - Layout/EmptyLinesAroundExceptionHandlingKeywords
 - Layout/EmptyLinesAroundMethodBody
 - Layout/EmptyLinesAroundModuleBody
-- Layout/EndOfLine
 - Layout/ExtraSpacing
 - Layout/FirstParameterIndentation
 - Layout/IndentArray


### PR DESCRIPTION
This fixes the `Style/EndOfLine has the wrong namespace - should be Layout`
warning, and uses the existing tools to disable the cop across all configs.