### PR TITLE
(maint) Update ruby versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -7,15 +7,15 @@
     '*.sh': 'eol=lf'
 .travis.yml:
   ruby_versions:
-    - 2.3.1
-    - 2.1.7
+    - 2.4.1
+    - 2.1.9
   bundler_args: --without system_tests
   env:
     - PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
   docker_sets:
   docker_defaults:
     # values will replace @@SET@@ with the docker_sets' value
-    rvm: 2.3.1
+    rvm: 2.4.1
     sudo: required
     dist: trusty
     services: docker


### PR DESCRIPTION
According to https://docs.puppet.com/puppet/5.1/about_agent.html
and https://docs.puppet.com/puppet/4.10/about_agent.html the
interesting ruby versions are 2.4.1 and 2.1.9.

This fixes both appveyor and travis configs.