### PR TITLE
(PDK-599) Add `rake` gem to Gemfile for ruby versions 1.x

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -169,6 +169,11 @@ elsif Gem.win_platform?
   gems['win32-service'] =  ['<= 0.8.8', require: false]
 end
 
+if RUBY_VERSION.start_with?('1.')
+  # Ruby < 2.0.0 doesn't come pre-installed with rake, so we need the gem.
+  gems['rake'] = ['1< 12.1.0']
+end
+
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end


### PR DESCRIPTION
Addresses ticket [PDK-599](https://tickets.puppetlabs.com/browse/PDK-599).

Travis fails on PDK-generated modules for Ruby versions < `2.0.0` due to lack of built-in `rake`.