### PR TITLE
(PDK-599) Update Gemfile for Travis CI

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -518,3 +518,17 @@ Gemfile:
     #     from_env: BEAKER_HOSTGENERATOR_VERSION
     #   - gem: beaker-rspec
     #     from_env: BEAKER_RSPEC_VERSION
+    # Everything in the `travisci` group has a condition of ENV['TRAVIS'].
+    # Some also have additional conditions based on ruby versions.
+    ':travisci':
+      - gem: 'rake'
+        version: '< 12.1.0'
+        condition: "ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
+      - gem: 'puppetlabs_spec_helper'
+        condition: "ENV['TRAVIS']"
+      - gem: 'rubocop'
+        condition: "ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
+      - gem: 'rubocop-rspec'
+        condition: "ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
+      - gem: 'metadata-json-lint'
+        condition: "ENV['TRAVIS'] and Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -477,20 +477,28 @@ Gemfile:
       - gem: json
         version: '= 1.8.1'
         condition: "Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')"
+      # Only supported for ruby >= 2.0.0
       - gem: 'puppet-module-posix-default-r#{minor_version}'
         platforms: ruby
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
+      # Only supported for ruby >= 2.0.0
       - gem: 'puppet-module-posix-dev-r#{minor_version}'
         platforms: ruby
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
+      # Only supported for ruby >= 2.0.0
       - gem: 'puppet-module-win-default-r#{minor_version}'
         platforms:
           - mswin
           - mingw
           - x64_mingw
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
+      # Only supported for ruby >= 2.0.0
       - gem: 'puppet-module-win-dev-r#{minor_version}'
         platforms:
           - mswin
           - mingw
           - x64_mingw
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
     # ':system_tests':
     #   - gem: 'puppet-module-posix-system-r#{minor_version}'
     #     platforms: ruby


### PR DESCRIPTION
Update the `Gemfile` to support testing on Ruby versions < `2.0.0` and to support testing on `Travis CI` .

I admit this is a brute-force approach and doesn't take into account any other CI/CD solution, but I don't know any other way to get a PDK-templated module to be successfully tested in Travis.