### PR TITLE
(PDK-377) remove hardcoded facterversion from tests

### DIFF
--- a/object_templates/class_spec.erb
+++ b/object_templates/class_spec.erb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe '<%= name %>' do
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 

--- a/object_templates/defined_type_spec.erb
+++ b/object_templates/defined_type_spec.erb
@@ -6,7 +6,7 @@ describe '<%= name %>' do
     {}
   end
 
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 


### PR DESCRIPTION
Now that facterdb is up-to-date, we can let rspec-puppet-facts choose the facterversion that is actually used in the environment.