### PR TITLE
(PDK-706) Remove vulnerable puppet3 support dependencies

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -61,6 +61,7 @@ def gem_type(place_or_version)
   end
 end
 
+# this is used to reference puppet-module gems by ruby version
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
@@ -100,66 +101,16 @@ puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
-def puppet_older_than?(version)
-  puppet_version = ENV['PUPPET_GEM_VERSION']
-  !puppet_version.nil? &&
-    Gem::Version.correct?(puppet_version) &&
-    Gem::Requirement.new("< #{version}").satisfied_by?(Gem::Version.new(puppet_version.dup))
-end
-
 gems = {}
 
 gems['puppet'] = location_for(puppet_version)
 
 # If facter or hiera versions have been specified via the environment
-# variables, use those versions. If not, and if the puppet version is < 3.5.0,
-# use known good versions of both for puppet < 3.5.0.
-if facter_version
-  gems['facter'] = location_for(facter_version)
-elsif puppet_type == :gem && puppet_older_than?('3.5.0')
-  gems['facter'] = ['>= 1.6.11', '<= 1.7.5', require: false]
-end
+# variables
+gems['facter'] = location_for(facter_version) if facter_version
+gems['hiera'] = location_for(hiera_version) if hiera_version
 
-if hiera_version
-  gems['hiera'] = location_for(ENV['HIERA_GEM_VERSION'])
-elsif puppet_type == :gem && puppet_older_than?('3.5.0')
-  gems['hiera'] = ['>= 1.0.0', '<= 1.3.0', require: false]
-end
-
-if Gem.win_platform? && (puppet_type != :gem || puppet_older_than?('3.5.0'))
-  # For Puppet gems < 3.5.0 (tested as far back as 3.0.0) on Windows
-  if puppet_type == :gem
-    gems['ffi'] =            ['1.9.0',                require: false]
-    gems['minitar'] =        ['0.5.4',                require: false]
-    gems['win32-eventlog'] = ['0.5.3',    '<= 0.6.5', require: false]
-    gems['win32-process'] =  ['0.6.5',    '<= 0.7.5', require: false]
-    gems['win32-security'] = ['~> 0.1.2', '<= 0.2.5', require: false]
-    gems['win32-service'] =  ['0.7.2',    '<= 0.8.8', require: false]
-  else
-    gems['ffi'] =            ['~> 1.9.0',             require: false]
-    gems['minitar'] =        ['~> 0.5.4',             require: false]
-    gems['win32-eventlog'] = ['~> 0.5',   '<= 0.6.5', require: false]
-    gems['win32-process'] =  ['~> 0.6',   '<= 0.7.5', require: false]
-    gems['win32-security'] = ['~> 0.1',   '<= 0.2.5', require: false]
-    gems['win32-service'] =  ['~> 0.7',   '<= 0.8.8', require: false]
-  end
-
-  gems['win32-dir'] = ['~> 0.3', '<= 0.4.9', require: false]
-
-  if RUBY_VERSION.start_with?('1.')
-    gems['win32console'] = ['1.3.2', require: false]
-    # sys-admin was removed in Puppet 3.7.0 and doesn't compile under Ruby 2.x
-    gems['sys-admin'] =    ['1.5.6', require: false]
-  end
-
-  # Puppet < 3.7.0 requires these.
-  # Puppet >= 3.5.0 gem includes these as requirements.
-  # The following versions are tested to work with 3.0.0 <= puppet < 3.7.0.
-  gems['win32-api'] =           ['1.4.8', require: false]
-  gems['win32-taskscheduler'] = ['0.2.2', require: false]
-  gems['windows-api'] =         ['0.4.3', require: false]
-  gems['windows-pr'] =          ['1.2.3', require: false]
-elsif Gem.win_platform?
+if Gem.win_platform?
   # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
   # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
   gems['win32-dir'] =      ['<= 0.4.9', require: false]


### PR DESCRIPTION
Since a few days the minitar < 0.6 dependency is being flagged by github's
vulnerability scanner, we remove it now, and drop final pretences at
supporting puppet 3.